### PR TITLE
fix: log but avoid crash for invalid device errors

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
         with:

--- a/packages/backend/src/core/ioc/bridge-environment.ts
+++ b/packages/backend/src/core/ioc/bridge-environment.ts
@@ -1,5 +1,5 @@
 import type { BridgeData } from "@home-assistant-matter-hub/common";
-import type { Environment } from "@matter/general";
+import type { Environment, Logger } from "@matter/general";
 import { Bridge } from "../../services/bridges/bridge.js";
 import { BridgeDataProvider } from "../../services/bridges/bridge-data-provider.js";
 import { BridgeEndpointManager } from "../../services/bridges/bridge-endpoint-manager.js";
@@ -19,13 +19,14 @@ export class BridgeEnvironment extends EnvironmentBase {
   }
 
   private readonly construction: Promise<void>;
+  private readonly endpointManagerLogger: Logger;
 
   private constructor(parent: Environment, initialData: BridgeData) {
-    const log = parent
-      .get(LoggerService)
-      .get(`BridgeEnvironment / ${initialData.id}`);
+    const loggerService = parent.get(LoggerService);
+    const log = loggerService.get(`BridgeEnvironment / ${initialData.id}`);
 
     super({ id: initialData.id, parent, log });
+    this.endpointManagerLogger = loggerService.get("BridgeEndpointManager");
     this.construction = this.init();
 
     this.set(BridgeDataProvider, new BridgeDataProvider(initialData));
@@ -44,6 +45,7 @@ export class BridgeEnvironment extends EnvironmentBase {
       new BridgeEndpointManager(
         await this.load(HomeAssistantClient),
         this.get(BridgeRegistry),
+        this.endpointManagerLogger,
       ),
     );
   }

--- a/packages/backend/src/services/bridges/bridge-endpoint-manager.ts
+++ b/packages/backend/src/services/bridges/bridge-endpoint-manager.ts
@@ -1,8 +1,10 @@
+import type { Logger } from "@matter/general";
 import type { Endpoint } from "@matter/main";
 import { Service } from "../../core/ioc/service.js";
 import { AggregatorEndpoint } from "../../matter/endpoints/aggregator-endpoint.js";
 import type { EntityEndpoint } from "../../matter/endpoints/entity-endpoint.js";
 import { LegacyEndpoint } from "../../matter/endpoints/legacy/legacy-endpoint.js";
+import { InvalidDeviceError } from "../../utils/errors/invalid-device-error.js";
 import { subscribeEntities } from "../home-assistant/api/subscribe-entities.js";
 import type { HomeAssistantClient } from "../home-assistant/home-assistant-client.js";
 import type { HomeAssistantStates } from "../home-assistant/home-assistant-registry.js";
@@ -16,6 +18,7 @@ export class BridgeEndpointManager extends Service {
   constructor(
     private readonly client: HomeAssistantClient,
     private readonly registry: BridgeRegistry,
+    private readonly log: Logger,
   ) {
     super("BridgeEndpointManager");
     this.root = new AggregatorEndpoint("aggregator");
@@ -62,7 +65,22 @@ export class BridgeEndpointManager extends Service {
     for (const entityId of this.entityIds) {
       let endpoint = existingEndpoints.find((e) => e.entityId === entityId);
       if (!endpoint) {
-        endpoint = await LegacyEndpoint.create(this.registry, entityId);
+        try {
+          endpoint = await LegacyEndpoint.create(this.registry, entityId);
+        } catch (e) {
+          if (e instanceof InvalidDeviceError) {
+            this.log.warn(
+              `Invalid device detected. Entity: ${entityId} Reason: ${(e as Error).message}`,
+            );
+            continue;
+          } else {
+            this.log.error(
+              `Failed to create device ${entityId}. Error: ${e?.toString()}`,
+            );
+            throw e;
+          }
+        }
+
         if (endpoint) {
           await this.root.add(endpoint);
         }

--- a/packages/backend/src/services/bridges/bridge-registry.ts
+++ b/packages/backend/src/services/bridges/bridge-registry.ts
@@ -49,9 +49,10 @@ export class BridgeRegistry {
   refresh() {
     this._entities = pickBy(this.registry.entities, (entity) => {
       const device = this.registry.devices[entity.entity_id];
-      const isHidden =
-        this.isHiddenOrDisabled(this.dataProvider.featureFlags ?? {}, entity) ??
-        [];
+      const isHidden = this.isHiddenOrDisabled(
+        this.dataProvider.featureFlags ?? {},
+        entity,
+      );
       const matchesFilter = this.matchesFilter(
         this.dataProvider.filter,
         entity,


### PR DESCRIPTION
Fixes 844
Fixes 840

Addon version 3.0.0-alpha.87 did not crash with these same device errors, it just logged a WARNING. So it seems that commit xxxx4afb86469268dca6ed4f1103cc316f64c2a182ec is what has caused this error to become fatal and cause the service to entirely crash, likely due to matter dep bump.

---
Copy of 