### PR TITLE
fix: avoid transaction locks in applyPatchState by assigning each key

### DIFF
--- a/packages/backend/src/utils/apply-patch-state.test.ts
+++ b/packages/backend/src/utils/apply-patch-state.test.ts
@@ -128,4 +128,51 @@ describe("applyPatchState", () => {
     expect(patch).toEqual({ a: 0, b: 0, d: 0 });
     expect(state).toEqual({ a: 0, b: 0, c: 0, d: 0 });
   });
+
+  it("should handle rapid sequential updates without errors", () => {
+    let updateCount = 0;
+
+    // Simulate many rapid state changes
+    for (let i = 0; i < 1000; i++) {
+      const patch = applyPatchState(state, {
+        health: i % 2 === 0 ? 90 : 95,
+        name: i % 2 === 0 ? "knight" : "awesome knight",
+        weapons: i % 3 === 0 ? ["bow"] : ["axe", "sword"],
+      });
+      if (Object.keys(patch).length > 0) {
+        updateCount++;
+      }
+    }
+
+    expect(state.health).toBe(95);
+    expect(state.name).toBe("awesome knight");
+    expect(state.weapons).toEqual(["bow"]);
+    expect(updateCount).toBeGreaterThan(0);
+  });
+
+  it("should work correctly with objects that have property setters", () => {
+    let setterCallCount = 0;
+    const stateWithSetters = {
+      _value: 0,
+      get value() {
+        return this._value;
+      },
+      set value(v: number) {
+        setterCallCount++;
+        this._value = v;
+      },
+      normalProp: "test",
+    };
+
+    const patch = applyPatchState(stateWithSetters, {
+      value: 42,
+      normalProp: "updated",
+    });
+
+    // Setter should be invoked by property assignment
+    expect(setterCallCount).toBe(1);
+    expect(stateWithSetters.value).toBe(42);
+    expect(stateWithSetters.normalProp).toBe("updated");
+    expect(patch).toEqual({ value: 42, normalProp: "updated" });
+  });
 });

--- a/packages/backend/src/utils/apply-patch-state.ts
+++ b/packages/backend/src/utils/apply-patch-state.ts
@@ -1,27 +1,38 @@
-import { size } from "lodash-es";
-
-export function applyPatchState<T extends {}>(
+export function applyPatchState<T extends object>(
   state: T,
   patch: Partial<T>,
 ): Partial<T> {
+  // Only include values that need to be changed
   const actualPatch: Partial<T> = {};
-  const keys = Object.keys(patch) as Array<keyof T>;
-  for (const key of keys) {
-    const patchValue = patch[key];
-    if (patchValue !== undefined && !deepEqual(state[key], patchValue)) {
-      actualPatch[key] = patchValue!;
+
+  for (const key in patch) {
+    if (Object.hasOwn(patch, key)) {
+      const patchValue = patch[key];
+
+      if (patchValue !== undefined) {
+        const stateValue = state[key];
+
+        if (!deepEqual(stateValue, patchValue)) {
+          actualPatch[key] = patchValue;
+        }
+      }
     }
   }
-  if (size(actualPatch) > 0) {
-    try {
-      Object.assign(state, actualPatch);
-    } catch (e) {
-      throw new Error(
-        `Failed to patch the following properties: ${JSON.stringify(actualPatch, null, 2)}`,
-        { cause: e },
-      );
+
+  // et properties individually to avoid transaction conflicts
+  try {
+    for (const key in actualPatch) {
+      if (Object.hasOwn(actualPatch, key)) {
+        state[key] = actualPatch[key] as T[Extract<keyof T, string>];
+      }
     }
+  } catch (e) {
+    throw new Error(
+      `Failed to patch the following properties: ${JSON.stringify(actualPatch, null, 2)}`,
+      { cause: e },
+    );
   }
+
   return actualPatch;
 }
 


### PR DESCRIPTION
## Fix transaction deadlock in applyPatchState

### Problem
Matter.js state objects use property setters with transaction locking. When `Object.assign()` is used to apply multiple properties at once, it can acquire multiple transaction locks simultaneously, leading to deadlocks.

This manifested as:
- `SetStateOf is already waiting` warnings in logs
- Unhandled promise rejection with reason "3"
- Bridge crashes under normal operation

Related upstream issues: 218, 422

### Solution
Changed `applyPatchState` from using `Object.assign()` to individual property assignment in a loop. This ensures each property's transaction lock is acquired and released sequentially, preventing deadlocks.

### Testing
- Added test for rapid sequential updates (simulates real-world usage pattern)
- Added test for objects with property setters (validates fix works with setter-based properties)
- Verified fix resolves crashes in production environment